### PR TITLE
アカウント認証でのメッセージ設定を追加して、へんな英語メッセージが出ないようにした

### DIFF
--- a/twitcasting/accountManager.py
+++ b/twitcasting/accountManager.py
@@ -15,6 +15,7 @@ import base64
 import copy
 import views.accountManager
 import sys
+import globalVars
 
 class AccountManager:
 	def __init__(self):
@@ -62,11 +63,17 @@ class AccountManager:
 
 	def add(self):
 		manager = implicitGrantManager.ImplicitGrantManager("ckitabatake1013.48f1b75c1355aad8230bf1f36eb0c29b1ef04cf8047c41c1a03a566b545342fd","https://apiv2.twitcasting.tv/oauth2/authorize",9338)
+		l="ja"
+		try:
+			l=globalVars.app.config["general"]["language"].split("_")[0].lower()
+		except:
+			pass#end うまく読めなかったら ja を採用
+		#end except
 		manager.setMessage(
-			lang="ja",
-			success="認証に成功しました。このウィンドウを閉じて、アプリケーションに戻ってください。",
-			failed="認証に失敗しました。もう一度お試しください。",
-			transfer="しばらくしても画面が切り替わらない場合は、別のブラウザでお試しください。"
+			lang=l,
+			success=_("認証に成功しました。このウィンドウを閉じて、アプリケーションに戻ってください。"),
+			failed=_("認証に失敗しました。もう一度お試しください。"),
+			transfer=_("しばらくしても画面が切り替わらない場合は、別のブラウザでお試しください。")
 		)
 		webbrowser.open(manager.getUrl())
 		d = views.accountManager.waitingDialog()

--- a/twitcasting/accountManager.py
+++ b/twitcasting/accountManager.py
@@ -62,6 +62,12 @@ class AccountManager:
 
 	def add(self):
 		manager = implicitGrantManager.ImplicitGrantManager("ckitabatake1013.48f1b75c1355aad8230bf1f36eb0c29b1ef04cf8047c41c1a03a566b545342fd","https://apiv2.twitcasting.tv/oauth2/authorize",9338)
+		manager.setMessage(
+			lang="ja",
+			success="認証に成功しました。このウィンドウを閉じて、アプリケーションに戻ってください。",
+			failed="認証に失敗しました。もう一度お試しください。",
+			transfer="しばらくしても画面が切り替わらない場合は、別のブラウザでお試しください。"
+		)
 		webbrowser.open(manager.getUrl())
 		d = views.accountManager.waitingDialog()
 		d.Initialize()


### PR DESCRIPTION
新規にアカウントを追加すると、認証結果が日本語で表示されるようになります。
デフォルトの英語のメッセージは、あれはあれでへんなので、ライブラリ側に修正入れます。