### PR TITLE
Bump soundPlayer to 0.2.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 beautifulsoup4
 lxml
 pyperclip
-https://github.com/actlaboratory/soundPlayer/archive/0.2.2.zip
+https://github.com/actlaboratory/soundPlayer/archive/0.2.4.zip
 https://github.com/actlaboratory/implicitGrantManager/archive/v1.2.2.zip
 https://github.com/actlaboratory/diff_archiver/archive/v1.0.1.zip
 https://github.com/actlaboratory/proxyUtil/archive/0.2.2.zip


### PR DESCRIPTION
pip install --upgrade するたびに0.2.2に戻ってLAMPとずれちゃってたのであげる。更新履歴を見る感じ、上げて大丈夫そう。