### PR TITLE
copyrightがcopylightになってたのを修正

### DIFF
--- a/constants.py
+++ b/constants.py
@@ -15,7 +15,7 @@ APP_LICENSE="GNU General Public License2.0 or later"
 APP_DEVELOPERS="Kazto Kitabatake, ACT Laboratory"
 APP_DEVELOPERS_URL="https://actlab.org/"
 APP_DETAILS_URL="https://actlab.org/software/TCV"
-APP_COPYRIGHT_MESSAGE = "Copyright (c) %s %s All lights reserved." % (APP_COPYRIGHT_YEAR, APP_DEVELOPERS)
+APP_COPYRIGHT_MESSAGE = "Copyright (c) %s %s All rights reserved." % (APP_COPYRIGHT_YEAR, APP_DEVELOPERS)
 
 #対応言語
 SUPPORTING_LANGUAGE={"ja-JP": "日本語","en-US": "English"}

--- a/public/license.txt
+++ b/public/license.txt
@@ -1,4 +1,4 @@
-CopyLight (c)2019-2021 Kazto Kitabatake,ACT laboratory All lights reserved.
+Copyright (c)2019-2021 Kazto Kitabatake,ACT laboratory All rights reserved.
 
 本ソフトウェアは、GPL v3(or later)またはApache license v2の条件に従い、自由に利用することができます。
 本ソフトウェアのソースコードは、readme.txtに記載のURLよりダウンロード可能です。


### PR DESCRIPTION
lightは光です。rightは権利です。