### PR TITLE
掲示板のアドレスの修正

### DIFF
--- a/public/readme.txt
+++ b/public/readme.txt
@@ -581,4 +581,4 @@ TCVのバージョン番号を確認できます。
 このソフトウェアを利用しての感想やご要望、不具合のご報告などは、以下のメールアドレスまたは掲示板へご連絡ください。
 
 ACT Laboratory サポート：support@actlab.org
-ACT Laboratory 掲示板：https://actlab.org/bbs/
+ACT Laboratory 掲示板：https://actlab.org/bbs/light.cgi


### PR DESCRIPTION
ヘルプファイル（readme.txt）から掲示板のアドレスを開くと、403エラーになってしまうため、トップページに掲載してある掲示板のアドレスに修正しています。
